### PR TITLE
Fixes missing GET variables when local wallet calls local browser

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -635,7 +635,7 @@ void MainWindow::doLogin(QStringList components)
     }
 
     QUrl url("http://" + QStringList(components.mid(2)).join('/'));
-    QUrlQuery query;
+    QUrlQuery query(url.query());
     query.addQueryItem("client_key",  fc::variant(bts::blockchain::public_key_type(myOneTimeKey.get_public_key())).as_string().c_str());
     query.addQueryItem("client_name", loginUser.c_str());
     query.addQueryItem("server_key", fc::variant(serverOneTimeKey).as_string().c_str());


### PR DESCRIPTION
When the user's browser calls the local wallet it is given a callback URL.  This callback URL was having GET variables stripped out.  Nathan suggested this fix and I tested it on my windows computer and it seemed to fix the issue.